### PR TITLE
Fix typo

### DIFF
--- a/payment/paysafecard-payment.js
+++ b/payment/paysafecard-payment.js
@@ -38,7 +38,7 @@ PaysafecardPayment.prototype.getResponse = function() {
   }
 };
 
-PaysafecardPayment.prototype.getRequestPrameter = function() {
+PaysafecardPayment.prototype.getRequestParameter = function() {
   // get request parameter
   var self = this;
 


### PR DESCRIPTION
This PR fixes a typo in the name of a function `getRequestParameter`